### PR TITLE
Fix mk 187

### DIFF
--- a/CustomEcommerce/NopCommerce/Presentation/Nop.Web/Themes/MarketTheme/Views/Shared/Components/HomepageProducts/Default.cshtml
+++ b/CustomEcommerce/NopCommerce/Presentation/Nop.Web/Themes/MarketTheme/Views/Shared/Components/HomepageProducts/Default.cshtml
@@ -134,7 +134,7 @@
                             regularDiscountContainer.owlCarousel({
                                 autoplay: false,
                                 loop: false,
-                                rtl: false,
+                                rtl: true,
                                 responsiveClass: true,
                                 autoHeight: false,
                                 navigation: true,


### PR DESCRIPTION
This fixed the heart icons' location on the regular discounts cards that are below the high discounts cards. The hearts used to be on the left. they are now positioned on the right.

This also fixed a weird behavior with the navigation of the carousel for these cards, where the cards will move differently than the carrousel on top.