### PR TITLE
MK-209:Carousel steering and behavior adjustment

### DIFF
--- a/CustomEcommerce/NopCommerce/Presentation/Nop.Web/Themes/MarketTheme/Views/Shared/Components/HomepageProducts/Default.cshtml
+++ b/CustomEcommerce/NopCommerce/Presentation/Nop.Web/Themes/MarketTheme/Views/Shared/Components/HomepageProducts/Default.cshtml
@@ -99,8 +99,8 @@
                             highDiscountContainer.addClass('owl-carousel px_featured');
                             highDiscountContainer.owlCarousel({
                                 autoplay: false,
-                                loop: false,
-                                rtl: true,
+                                loop: true,
+                                rtl: false,
                                 responsiveClass: true,
                                 navigation: true,
                                 dots: false,
@@ -133,8 +133,8 @@
                             regularDiscountContainer.addClass('owl-carousel px_featured');
                             regularDiscountContainer.owlCarousel({
                                 autoplay: false,
-                                loop: false,
-                                rtl: true,
+                                loop: true,
+                                rtl: false,
                                 responsiveClass: true,
                                 autoHeight: false,
                                 navigation: true,
@@ -169,8 +169,8 @@
                     highDiscountContainer.css('width', '60%');
                     highDiscountContainer.owlCarousel({
                         autoplay: false,
-                        loop: false,
-                        rtl: true,
+                        loop: true,
+                        rtl: false,
                         responsiveClass: true,
                         autoHeight: true,
                         navigation: true,
@@ -198,8 +198,8 @@
                     regularDiscountContainer.addClass('owl-carousel px_featured');
                     regularDiscountContainer.owlCarousel({
                         autoplay: false,
-                        loop: false,
-                        rtl: true,
+                        loop: true,
+                        rtl: false,
                         responsiveClass: true,
                         autoHeight: true,
                         navigation: true,


### PR DESCRIPTION
This update changes the order of how the items in the carrousels are being displayed. "rtl" stands for "Right to Left" this was true for all the carousels, this is why their navigation was backwards.

And the loop variable enables the carousels to have infinite loop.