### PR TITLE
Increase page size for super deals products

### DIFF
--- a/CustomEcommerce/NopCommerce/Presentation/Nop.Web/Components/SuperDealsViewComponent.cs
+++ b/CustomEcommerce/NopCommerce/Presentation/Nop.Web/Components/SuperDealsViewComponent.cs
@@ -78,8 +78,9 @@ namespace Nop.Web.Components
                     storeId: currentStore.Id,
                     visibleIndividuallyOnly: true,
                     overridePublished: true,
-                    pageSize: 10,
-                    orderBy: ProductSortingEnum.PriceDesc
+                    pageSize: 40,
+                    orderBy: ProductSortingEnum.PriceDesc,
+                    pageIndex: 0
                 );
 
                 var categoryProducts = products.Take(15).ToList();


### PR DESCRIPTION
Updated the SuperDealsViewComponent to fetch 40 products instead of 10 and explicitly set pageIndex to 0. This allows more products to be considered for the super deals display.